### PR TITLE
Fix: Mengatasi duplicate operation ID di FastAPI

### DIFF
--- a/app/domains/ppob/controllers/ppob_controller.py
+++ b/app/domains/ppob/controllers/ppob_controller.py
@@ -90,7 +90,8 @@ class PPOBController:
             "/stats",
             self.get_transaction_stats,
             methods=["GET"],
-            response_model=APIResponse[PPOBStatsResponse]
+            response_model=APIResponse[PPOBStatsResponse],
+            operation_id="get_ppob_transaction_stats"
         )
         self.router.add_api_route(
             "/popular-products",
@@ -104,7 +105,8 @@ class PPOBController:
             "/admin/stats",
             self.get_admin_stats,
             methods=["GET"],
-            response_model=APIResponse[PPOBStatsResponse]
+            response_model=APIResponse[PPOBStatsResponse],
+            operation_id="get_ppob_admin_stats"
         )
         self.router.add_api_route(
             "/admin/revenue/{year}/{month}",

--- a/app/domains/transaction/controllers/transaction_controller.py
+++ b/app/domains/transaction/controllers/transaction_controller.py
@@ -10,7 +10,7 @@ from app.shared.responses.api_response import APIResponse
 
 router = APIRouter()
 
-@router.get("/recent")
+@router.get("/recent", operation_id="get_admin_recent_transactions")
 async def list_recent_transactions(
     limit: int = Query(5, ge=1, le=50, description="Jumlah transaksi terbaru"),
     current_admin: Admin = Depends(get_current_admin),
@@ -89,7 +89,7 @@ async def list_recent_transactions(
             detail=f"Gagal mengambil transaksi terbaru: {str(e)}"
         )
 
-@router.get("/")
+@router.get("/", operation_id="get_admin_all_transactions")
 async def list_all_transactions(
     page: int = Query(1, ge=1, description="Halaman"),
     size: int = Query(10, ge=1, le=100, description="Jumlah per halaman"),
@@ -149,7 +149,7 @@ async def list_all_transactions(
             detail=f"Gagal mengambil transaksi: {str(e)}"
         )
 
-@router.get("/stats")
+@router.get("/stats", operation_id="get_admin_transaction_stats")
 async def list_transaction_stats(
     current_admin: Admin = Depends(get_current_admin),
     db: Session = Depends(get_db)


### PR DESCRIPTION
- Menambahkan operation_id unik untuk setiap endpoint yang konflik
- Menghapus duplikasi router registration di admin_controller.py
- Memisahkan transaction endpoints ke controller terpisah
- Mengatasi warning: Duplicate Operation ID get_recent_transactions, get_all_transactions, get_transaction_stats

Perubahan:
- admin_controller.py: Menambah operation_id untuk admin endpoints, hapus TransactionController duplikat
- transaction_controller.py: Menambah operation_id unik untuk transaction endpoints