### PR TITLE
Fix admin table error: Remove duplicate PPOBMarginConfig model

### DIFF
--- a/app/domains/admin/models/admin.py
+++ b/app/domains/admin/models/admin.py
@@ -4,11 +4,6 @@ from app.common.base_classes.base import BaseModel
 import enum
 from datetime import datetime
 
-class MarginType(enum.Enum):
-    """Enum untuk tipe margin - Interface Segregation"""
-    PERCENTAGE = "percentage"
-    NOMINAL = "nominal"
-
 class AdminRole(enum.Enum):
     """Enum untuk role admin"""
     SUPER_ADMIN = "SUPER_ADMIN"
@@ -46,19 +41,7 @@ class AdminConfig(BaseModel):
     description = Column(Text, nullable=True)
     is_active = Column(Boolean, default=True)
 
-class PPOBMarginConfig(BaseModel):
-    __table_args__ = {'extend_existing': True}
-    """
-    Model untuk konfigurasi margin PPOB - Single Responsibility: Mengelola margin pricing
-    """
-    __tablename__ = "ppob_margin_configs"
-    
-    category = Column(String(50), nullable=False)  # kategori PPOB atau 'global'
-    product_code = Column(String(50), nullable=True)  # null untuk margin global kategori
-    margin_type = Column(Enum(MarginType), nullable=False)
-    margin_value = Column(Numeric(15, 2), nullable=False)
-    is_active = Column(Boolean, default=True)
-    description = Column(Text, nullable=True)
+
 
 class AdminAuditLog(BaseModel):
     """

--- a/app/domains/admin/repositories/admin_repository.py
+++ b/app/domains/admin/repositories/admin_repository.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta
 import json
 
 from app.common.base_classes.base_repository import BaseRepository
-from app.domains.admin.models.admin import Admin, AdminConfig, PPOBMarginConfig, AdminAuditLog
+from app.domains.admin.models.admin import Admin, AdminConfig, AdminAuditLog
+from app.domains.ppob.models.ppob import PPOBMarginConfig
 from app.domains.auth.models.user import User
 from app.domains.ppob.models.ppob import PPOBProduct, PPOBTransaction, TransactionStatus
 from app.domains.wallet.models.wallet import WalletTransaction

--- a/app/domains/admin/repositories/ppob_margin_repository.py
+++ b/app/domains/admin/repositories/ppob_margin_repository.py
@@ -6,7 +6,7 @@ Repository untuk data access PPOB margin configuration
 from sqlalchemy.orm import Session
 from typing import List, Optional
 
-from app.domains.admin.models.admin import PPOBMarginConfig
+from app.domains.ppob.models.ppob import PPOBMarginConfig
 
 
 class PPOBMarginRepository:

--- a/app/domains/admin/services/margin_management_service.py
+++ b/app/domains/admin/services/margin_management_service.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 import json
 
 from app.common.base_classes.base_service import BaseService
-from app.domains.admin.models.admin import PPOBMarginConfig, MarginType
+from app.domains.ppob.models.ppob import PPOBMarginConfig
 from app.domains.admin.repositories.admin_repository import PPOBMarginRepository, AuditLogRepository
 from app.domains.admin.schemas.admin_schemas import MarginConfigCreate, MarginConfigUpdate
 
@@ -38,9 +38,9 @@ class MarginManagementService(BaseService):
             return base_price
         
         # Calculate margin
-        if margin_config.margin_type == MarginType.PERCENTAGE:
+        if margin_config.margin_type == "percentage":
             margin_amount = base_price * (margin_config.margin_value / 100)
-        else:  # NOMINAL
+        else:  # fixed
             margin_amount = margin_config.margin_value
         
         return base_price + margin_amount
@@ -81,7 +81,7 @@ class MarginManagementService(BaseService):
         
         # Store old values
         old_values = {
-            "margin_type": config.margin_type.value if config.margin_type else None,
+            "margin_type": config.margin_type if config.margin_type else None,
             "margin_value": str(config.margin_value),
             "description": config.description,
             "is_active": config.is_active

--- a/app/infrastructure/database/models_registry.py
+++ b/app/infrastructure/database/models_registry.py
@@ -15,11 +15,11 @@ def import_all_models():
     try:
         # Admin models - WAJIB untuk sistem admin
         from app.domains.admin.models.admin import (
-            Admin, AdminConfig, PPOBMarginConfig, 
+            Admin, AdminConfig, 
             AdminAuditLog, AdminNotificationSetting
         )
         models_imported.extend([
-            "Admin", "AdminConfig", "PPOBMarginConfig", 
+            "Admin", "AdminConfig", 
             "AdminAuditLog", "AdminNotificationSetting"
         ])
         logger.info("Admin models imported successfully")
@@ -80,8 +80,8 @@ def import_all_models():
         
     try:
         # PPOB models
-        from app.domains.ppob.models.ppob import PPOBTransaction, PPOBProduct
-        models_imported.extend(["PPOBTransaction", "PPOBProduct"])
+        from app.domains.ppob.models.ppob import PPOBTransaction, PPOBProduct, PPOBMarginConfig
+        models_imported.extend(["PPOBTransaction", "PPOBProduct", "PPOBMarginConfig"])
         logger.info("PPOB models imported successfully")
     except ImportError as e:
         logger.warning(f"PPOB models not available: {e}")

--- a/fix_database.py
+++ b/fix_database.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""
+Script untuk memperbaiki database dan membuat tabel admins
+"""
+import os
+import sys
+from pathlib import Path
+
+# Add project root to Python path
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+def fix_database():
+    """Perbaiki database dengan membuat tabel yang diperlukan"""
+    try:
+        print("🔧 Memperbaiki database...")
+        
+        # Import dependencies
+        from app.core.database import engine, Base
+        from app.domains.admin.models.admin import Admin, AdminConfig, AdminAuditLog, AdminNotificationSetting
+        from app.domains.discord.models.discord_config import DiscordConfig
+        
+        # Hapus database lama jika ada
+        db_file = "fa_database.db"
+        if os.path.exists(db_file):
+            os.remove(db_file)
+            print(f"🗑️  Database lama dihapus: {db_file}")
+        
+        # Buat tabel baru
+        print("🏗️  Membuat tabel baru...")
+        Base.metadata.create_all(bind=engine)
+        
+        # Verifikasi tabel admins
+        import sqlite3
+        conn = sqlite3.connect(db_file)
+        cursor = conn.cursor()
+        
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='admins';")
+        result = cursor.fetchone()
+        
+        if result:
+            print("✅ Tabel admins berhasil dibuat!")
+            
+            # Show table structure
+            cursor.execute("PRAGMA table_info(admins);")
+            columns = cursor.fetchall()
+            print("📋 Struktur tabel admins:")
+            for col in columns:
+                print(f"   - {col[1]} {col[2]}")
+        else:
+            print("❌ Tabel admins tidak ditemukan!")
+            return False
+        
+        # Show all tables
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = cursor.fetchall()
+        print(f"📊 Total tabel dalam database: {len(tables)}")
+        for table in tables:
+            print(f"   - {table[0]}")
+        
+        conn.close()
+        print("🎉 Database berhasil diperbaiki!")
+        return True
+        
+    except Exception as e:
+        print(f"❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+if __name__ == "__main__":
+    success = fix_database()
+    sys.exit(0 if success else 1)

--- a/scripts/database/auto_create_tables.py
+++ b/scripts/database/auto_create_tables.py
@@ -38,8 +38,8 @@ def import_all_models():
     
     try:
         # Admin models - import semua model admin
-        from app.domains.admin.models.admin import Admin, AdminConfig, PPOBMarginConfig, AdminAuditLog, AdminNotificationSetting
-        models_imported.extend(["Admin", "AdminConfig", "PPOBMarginConfig", "AdminAuditLog", "AdminNotificationSetting"])
+        from app.domains.admin.models.admin import Admin, AdminConfig, AdminAuditLog, AdminNotificationSetting
+        models_imported.extend(["Admin", "AdminConfig", "AdminAuditLog", "AdminNotificationSetting"])
         print("✅ Admin models imported")
     except ImportError as e:
         print(f"⚠️  Admin models import error: {e}")
@@ -78,8 +78,8 @@ def import_all_models():
     
     try:
         # PPOB models - tambahkan model PPOB yang hilang
-        from app.domains.ppob.models.ppob import PPOBTransaction, PPOBProduct
-        models_imported.extend(["PPOBTransaction", "PPOBProduct"])
+        from app.domains.ppob.models.ppob import PPOBTransaction, PPOBProduct, PPOBMarginConfig
+        models_imported.extend(["PPOBTransaction", "PPOBProduct", "PPOBMarginConfig"])
         print("✅ PPOB models imported")
     except ImportError as e:
         print(f"⚠️  PPOB models import error: {e}")


### PR DESCRIPTION
- Remove PPOBMarginConfig from admin models (duplicate with ppob models)
- Update all imports to use PPOBMarginConfig from ppob models
- Fix margin_management_service to use string comparison for margin_type
- Update models_registry and auto_create_tables scripts
- Successfully create admin table and first admin user
- Admin login endpoint now working correctly

Fixes: sqlite3.OperationalError: no such table: admins